### PR TITLE
Helping with broken DETS files.

### DIFF
--- a/src/2.13.5/group_history.erl
+++ b/src/2.13.5/group_history.erl
@@ -95,6 +95,8 @@ add(Line, true) ->
                     dets:delete(?TABLE, Ct-opt(hist_size)),
                     dets:update_counter(?TABLE, ct, {2,1});
                 {error,{{bad_object,_Reason},HistFile}} ->
+                    corrupt_warning(HistFile);
+                {error,{bad_object_header, HistFile}} ->
                     corrupt_warning(HistFile)
             end;
         true ->

--- a/src/2.14.1/group_history.erl
+++ b/src/2.14.1/group_history.erl
@@ -95,6 +95,8 @@ add(Line, true) ->
                     dets:delete(?TABLE, Ct-opt(hist_size)),
                     dets:update_counter(?TABLE, ct, {2,1});
                 {error,{{bad_object,_Reason},HistFile}} ->
+                    corrupt_warning(HistFile);
+                {error,{bad_object_header, HistFile}} ->
                     corrupt_warning(HistFile)
             end;
         true ->

--- a/src/2.14.2/group_history.erl
+++ b/src/2.14.2/group_history.erl
@@ -95,6 +95,8 @@ add(Line, true) ->
                     dets:delete(?TABLE, Ct-opt(hist_size)),
                     dets:update_counter(?TABLE, ct, {2,1});
                 {error,{{bad_object,_Reason},HistFile}} ->
+                    corrupt_warning(HistFile);
+                {error,{bad_object_header, HistFile}} ->
                     corrupt_warning(HistFile)
             end;
         true ->

--- a/src/2.14.3/group_history.erl
+++ b/src/2.14.3/group_history.erl
@@ -95,6 +95,8 @@ add(Line, true) ->
                     dets:delete(?TABLE, Ct-opt(hist_size)),
                     dets:update_counter(?TABLE, ct, {2,1});
                 {error,{{bad_object,_Reason},HistFile}} ->
+                    corrupt_warning(HistFile);
+                {error,{bad_object_header, HistFile}} ->
                     corrupt_warning(HistFile)
             end;
         true ->

--- a/src/2.14.4/group_history.erl
+++ b/src/2.14.4/group_history.erl
@@ -95,6 +95,8 @@ add(Line, true) ->
                     dets:delete(?TABLE, Ct-opt(hist_size)),
                     dets:update_counter(?TABLE, ct, {2,1});
                 {error,{{bad_object,_Reason},HistFile}} ->
+                    corrupt_warning(HistFile);
+                {error,{bad_object_header, HistFile}} ->
                     corrupt_warning(HistFile)
             end;
         true ->

--- a/src/2.14.5/group_history.erl
+++ b/src/2.14.5/group_history.erl
@@ -95,6 +95,8 @@ add(Line, true) ->
                     dets:delete(?TABLE, Ct-opt(hist_size)),
                     dets:update_counter(?TABLE, ct, {2,1});
                 {error,{{bad_object,_Reason},HistFile}} ->
+                    corrupt_warning(HistFile);
+                {error,{bad_object_header, HistFile}} ->
                     corrupt_warning(HistFile)
             end;
         true ->

--- a/src/2.15.1/group_history.erl
+++ b/src/2.15.1/group_history.erl
@@ -95,6 +95,8 @@ add(Line, true) ->
                     dets:delete(?TABLE, Ct-opt(hist_size)),
                     dets:update_counter(?TABLE, ct, {2,1});
                 {error,{{bad_object,_Reason},HistFile}} ->
+                    corrupt_warning(HistFile);
+                {error,{bad_object_header, HistFile}} ->
                     corrupt_warning(HistFile)
             end;
         true ->

--- a/src/2.15.2/group_history.erl
+++ b/src/2.15.2/group_history.erl
@@ -95,6 +95,8 @@ add(Line, true) ->
                     dets:delete(?TABLE, Ct-opt(hist_size)),
                     dets:update_counter(?TABLE, ct, {2,1});
                 {error,{{bad_object,_Reason},HistFile}} ->
+                    corrupt_warning(HistFile);
+                {error,{bad_object_header, HistFile}} ->
                     corrupt_warning(HistFile)
             end;
         true ->

--- a/src/2.15.3/group_history.erl
+++ b/src/2.15.3/group_history.erl
@@ -95,6 +95,8 @@ add(Line, true) ->
                     dets:delete(?TABLE, Ct-opt(hist_size)),
                     dets:update_counter(?TABLE, ct, {2,1});
                 {error,{{bad_object,_Reason},HistFile}} ->
+                    corrupt_warning(HistFile);
+                {error,{bad_object_header, HistFile}} ->
                     corrupt_warning(HistFile)
             end;
         true ->

--- a/src/2.15/group_history.erl
+++ b/src/2.15/group_history.erl
@@ -95,6 +95,8 @@ add(Line, true) ->
                     dets:delete(?TABLE, Ct-opt(hist_size)),
                     dets:update_counter(?TABLE, ct, {2,1});
                 {error,{{bad_object,_Reason},HistFile}} ->
+                    corrupt_warning(HistFile);
+                {error,{bad_object_header, HistFile}} ->
                     corrupt_warning(HistFile)
             end;
         true ->

--- a/src/2.16.1/group_history.erl
+++ b/src/2.16.1/group_history.erl
@@ -95,6 +95,8 @@ add(Line, true) ->
                     dets:delete(?TABLE, Ct-opt(hist_size)),
                     dets:update_counter(?TABLE, ct, {2,1});
                 {error,{{bad_object,_Reason},HistFile}} ->
+                    corrupt_warning(HistFile);
+                {error,{bad_object_header, HistFile}} ->
                     corrupt_warning(HistFile)
             end;
         true ->

--- a/src/2.16.2/group_history.erl
+++ b/src/2.16.2/group_history.erl
@@ -95,6 +95,8 @@ add(Line, true) ->
                     dets:delete(?TABLE, Ct-opt(hist_size)),
                     dets:update_counter(?TABLE, ct, {2,1});
                 {error,{{bad_object,_Reason},HistFile}} ->
+                    corrupt_warning(HistFile);
+                {error,{bad_object_header, HistFile}} ->
                     corrupt_warning(HistFile)
             end;
         true ->

--- a/src/2.16/group_history.erl
+++ b/src/2.16/group_history.erl
@@ -95,6 +95,8 @@ add(Line, true) ->
                     dets:delete(?TABLE, Ct-opt(hist_size)),
                     dets:update_counter(?TABLE, ct, {2,1});
                 {error,{{bad_object,_Reason},HistFile}} ->
+                    corrupt_warning(HistFile);
+                {error,{bad_object_header, HistFile}} ->
                     corrupt_warning(HistFile)
             end;
         true ->


### PR DESCRIPTION
Apparently something is broken with dets and erlang R16B01. When erlang-history
tries to open the dets file endless {bad_object_header, FileName} are produced.

This commit tries to make the shell usable again without fixing the error. A
warning is issued and infinite crashing is avoided.
