### PR TITLE
Handle history file access errors

### DIFF
--- a/src/3.1/group_history.erl
+++ b/src/3.1/group_history.erl
@@ -27,7 +27,11 @@ load() ->
             %% we wait to reply to ourselves in some circumstances.
             case dets:open_file(?TABLE, [{file,F}, {auto_save, opt(hist_auto_save)}, {repair, false}]) of
                 {ok, ?TABLE} -> load_history(S);
-                {error, {needs_repair, F}} -> repair_table(F)
+                {error, {needs_repair, F}} -> repair_table(F);
+                {error, _} ->
+                    %% Turn off history if all fails
+                    application:set_env(kernel, hist, false),
+                    []
             end
     end.
 


### PR DESCRIPTION
Admittedly my setup is special, since I'm running on embedded hardware where I have to handle some filesystems being corrupt or coming up read-only. When something happens to the place where the history file is stored, I lose access to the shell and get the unhelpful "ERROR: Shell process terminated!" error. This change just turns off the history feature if that happens, since that's way better than losing access to the shell completely. To test, point the history file to some place like "/root" or anywhere else that would give an eacces error.

Also, I only modified the 3.1 file since that's what I could test easily. FWIW, I tried to print a nice error message like you had, but ran into issues with the error message being printed twice despite trying to guard against that. It's clear that I don't quite understand the shell start sequence here. Without the nice error message, I do still get an error report with "permission denied" and the filename in the text, so that's better than nothing. Since this is such a corner case, I backed off and made the code as short as possible.

