### PR TITLE
Fix os:cmd(CopyCmd) not output error msg

### DIFF
--- a/install.escript
+++ b/install.escript
@@ -74,4 +74,4 @@ update_modules(Path, Version) ->
             [Version, Path]
             ),
     io:format("Installing...~n"),
-    io:format("~s", [os:cmd(CopyCmd)]).
+    io:format("~ts", [os:cmd(CopyCmd)]).


### PR DESCRIPTION
When copy is `permission denied`,  the error is like following:

``` shell
cp: cannot create regular file ‘/usr/local/Cellar/erlang/17.5/lib/erlang/lib/kernel-3.2/ebin/group.beam’
```

Notice the single quotes, they are \x{2018} and \x{2019} in unicode. Without the unicode translation modifier `~t`, it will raise exception.

Exception:
```
escript: exception error: bad argument
  in function  io:format/3
     called as io:format(<0.23.0>,"~s",
                         [[99,112,58,32,99,97,110,110,111,116,32,99,114,101,
                           97,116,101,32,114,101,103,117,108,97,114,32,102,
                           105,108,101,32,8216,47,117,115,114,47,108,111,99,
                           97,108,47,67,101|...]])
  in call from erl_eval:local_func/5 (erl_eval.erl, line 544)
  in call from escript:interpret/4 (escript.erl, line 781)
  in call from escript:start/1 (escript.erl, line 276)
  in call from init:start_it/1
  in call from init:start_em/1
make: *** [install] Error 127
```

But I don't know why it outputs single quotes like above.